### PR TITLE
feat(cli): parse forwarded ip

### DIFF
--- a/packages/cli/src/util/dev/get-request-ip.ts
+++ b/packages/cli/src/util/dev/get-request-ip.ts
@@ -1,0 +1,13 @@
+import type http from 'http';
+
+export default function getRequestIp(req: http.IncomingMessage): string {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string') {
+    const [firstIp] = forwardedFor.split(',');
+    if (firstIp) return firstIp.trim();
+  } else if (Array.isArray(forwardedFor) && forwardedFor.length > 0) {
+    const [firstIp] = forwardedFor[0].split(',');
+    if (firstIp) return firstIp.trim();
+  }
+  return req.connection.remoteAddress || '127.0.0.1';
+}

--- a/packages/cli/src/util/dev/server.ts
+++ b/packages/cli/src/util/dev/server.ts
@@ -98,6 +98,7 @@ import {
 import isURL from './is-url';
 import { pickOverrides } from '../projects/project-settings';
 import { replaceLocalhost } from './parse-listen';
+import getRequestIpFromHeaders from './get-request-ip';
 
 const frontendRuntimeSet = new Set(
   frameworkList.map(f => f.useRuntime?.use || '@vercel/static-build')
@@ -1156,8 +1157,7 @@ export default class DevServer {
   }
 
   getRequestIp(req: http.IncomingMessage): string {
-    // TODO: respect the `x-forwarded-for` headers
-    return req.connection.remoteAddress || '127.0.0.1';
+    return getRequestIpFromHeaders(req);
   }
 
   /**

--- a/packages/cli/test/unit/util/dev/get-request-ip.test.ts
+++ b/packages/cli/test/unit/util/dev/get-request-ip.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import type http from 'http';
+
+import getRequestIp from '../../../../src/util/dev/get-request-ip';
+
+describe('getRequestIp', () => {
+  it('uses x-forwarded-for header when available', () => {
+    const req = {
+      headers: { 'x-forwarded-for': '1.1.1.1, 2.2.2.2' },
+      connection: { remoteAddress: '9.9.9.9' },
+    } as unknown as http.IncomingMessage;
+    expect(getRequestIp(req)).toBe('1.1.1.1');
+  });
+
+  it('falls back to remote address when header missing', () => {
+    const req = {
+      headers: {},
+      connection: { remoteAddress: '9.9.9.9' },
+    } as unknown as http.IncomingMessage;
+    expect(getRequestIp(req)).toBe('9.9.9.9');
+  });
+});


### PR DESCRIPTION
## Summary
- parse `x-forwarded-for` header and fall back to connection address
- cover new IP parsing logic with unit tests

## Testing
- `pnpm exec eslint packages/cli/src/util/dev/server.ts packages/cli/src/util/dev/get-request-ip.ts packages/cli/test/unit/util/dev/get-request-ip.test.ts`
- `pnpm --filter vercel exec vitest run test/unit/util/dev/get-request-ip.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c7938893ec8325ba0eef51431dc648